### PR TITLE
List the IRIS in a city

### DIFF
--- a/pyris/api/app.py
+++ b/pyris/api/app.py
@@ -86,16 +86,33 @@ class IrisCode(Resource):
         return iris
 
 
-@api.route('/city/<string:code>')
+@api.route('/city/code/<string:code>')
 class IrisListFromCityCode(Resource):
     @api.doc(parser=api.parser(),
-             description="get the list of complete iris codes for a city code")
+             description="Look for all the iris codes in the city mathing the city code")
     def get(self, code):
-        Logger.info('looking for IRIS in the city code %s', code)
+        Logger.info("looking for IRIS in the city code %s", code)
         iris=extract.get_iris_list_by_city_code(code)
         if not iris:
             api.abort(404, "City code '{}' not found".format(code))
         return iris
+
+
+@api.route("/city/search/<string:query>")
+class IrisListFromCityCode(Resource):
+    @api.doc(parser=api.parser(),
+             description="Get the list of all the iris codes in the city matching the query")
+    def get(self, query):
+        Logger.info("Looking for the list of iris in the city matching the query %s", query)
+        Logger.info("Looking for longitude and latitude for the query %s", query)
+        coord=address.coordinate(query)
+        if coord["address"] is None:
+            return[]
+        # I'm pretty sure the preferred order is usually latitude first, then longitude
+        Logger.info("Looking for iris at coordinates %s, %s", coord["lat"], ["lon"])
+        iris=extract.iris_from_coordinate(coord["lon"], coord["lat"])
+        iris_list=extract.get_iris_list_by_city_code(iris["citycode"])
+        return iris_list
 
 
 @api.route("/coords")

--- a/pyris/api/app.py
+++ b/pyris/api/app.py
@@ -86,6 +86,18 @@ class IrisCode(Resource):
         return iris
 
 
+@api.route('/city/<string:code>')
+class IrisListFromCityCode(Resource):
+    @api.doc(parser=api.parser(),
+             description="get the list of complete iris codes for a city code")
+    def get(self, code):
+        Logger.info('looking for IRIS in the city code %s', code)
+        iris=extract.get_iris_list_by_city_code(code)
+        if not iris:
+            api.abort(404, "City code '{}' not found".format(code))
+        return iris
+
+
 @api.route("/coords")
 class IrisFromCoordinates(Resource):
     @api.doc(parser=coords_parser,

--- a/pyris/api/app.py
+++ b/pyris/api/app.py
@@ -99,7 +99,7 @@ class IrisListFromCityCode(Resource):
 
 
 @api.route("/city/search/<string:query>")
-class IrisListFromCityCode(Resource):
+class IrisListFromQuery(Resource):
     @api.doc(parser=api.parser(),
              description="Get the list of all the iris codes in the city matching the query")
     def get(self, query):

--- a/pyris/api/app.py
+++ b/pyris/api/app.py
@@ -114,7 +114,7 @@ class IrisListFromCityCode(Resource):
         Logger.info("Looking for iris at coordinates %s, %s", coord["lat"], ["lon"])
         iris=extract.iris_from_coordinate(coord["lon"], coord["lat"])
         iris_list=extract.get_iris_list_by_city_code(iris["citycode"])
-        return iris_list
+        return {"city_name": iris["city"], "city_code": iris["citycode"], "iris_list": iris_list}
 
 
 @api.route("/coords")

--- a/pyris/api/app.py
+++ b/pyris/api/app.py
@@ -89,9 +89,9 @@ class IrisCode(Resource):
 @api.route('/city/code/<string:code>')
 class IrisListFromCityCode(Resource):
     @api.doc(parser=api.parser(),
-             description="Look for all the iris codes in the city mathing the city code")
+             description="Look for all the iris codes in the city matching a city code")
     def get(self, code):
-        Logger.info("looking for IRIS in the city code %s", code)
+        Logger.info("looking for IRIS in the city %s", code)
         iris=extract.get_iris_list_by_city_code(code)
         if not iris:
             api.abort(404, "City code '{}' not found".format(code))
@@ -107,7 +107,9 @@ class IrisListFromCityCode(Resource):
         Logger.info("Looking for longitude and latitude for the query %s", query)
         coord=address.coordinate(query)
         if coord["address"] is None:
-            return[]
+            # Requests sent to '/api/search' that match nothing do not return a 404 error like other requests.
+            # Is this an intentional choice?
+            api.abort(404, "No city found matching that query")
         # I'm pretty sure the preferred order is usually latitude first, then longitude
         Logger.info("Looking for iris at coordinates %s, %s", coord["lat"], ["lon"])
         iris=extract.iris_from_coordinate(coord["lon"], coord["lat"])

--- a/pyris/api/extract.py
+++ b/pyris/api/extract.py
@@ -13,6 +13,7 @@ from pyris.config import DATABASE
 _HERE = os.path.abspath(os.path.dirname(__file__))
 _QUERY_DIR = os.path.join(_HERE, "queries")
 Q_IRIS = "iris.sql"
+Q_IRIS_BY_CITY_CODE = "iris_by_city_code.sql"
 Q_COMPIRIS = "complete_iris.sql"
 Q_COORD = "coordinate.sql"
 Q_POPULATION = "iris_population.sql"
@@ -120,6 +121,18 @@ def get_iris_field(code, limit=None, geojson=False):
                     "features": data}
         return data
     return res
+
+
+def get_iris_list_by_city_code(code):
+    """Get the list of IRIS in a city by its code
+    
+    code: str
+        City code. Five digits.
+    """
+    query=_load_sql_file(Q_IRIS_BY_CITY_CODE)
+    res=_query(query, (code,))
+    Logger.debug("res: %s", res)
+    return [x[0] for x in res] if res else res
 
 
 def get_complete_iris(code, geojson=False):

--- a/pyris/api/extract.py
+++ b/pyris/api/extract.py
@@ -130,6 +130,7 @@ def get_iris_list_by_city_code(code):
         City code. Five digits.
     """
     query=_load_sql_file(Q_IRIS_BY_CITY_CODE)
+    Logger.debug("Query: %s", query)
     res=_query(query, (code,))
     Logger.debug("res: %s", res)
     return [x[0] for x in res] if res else res

--- a/pyris/api/queries/iris_by_city_code.sql
+++ b/pyris/api/queries/iris_by_city_code.sql
@@ -1,0 +1,5 @@
+-- Get all the IRIS in a city by its code
+
+SELECT dcomiris
+FROM geoiris
+WHERE depcom = %s


### PR DESCRIPTION
I added 2 routes, `/api/city/code/<code>` and `/api/city/search/<query>`. 
`/api/city/code/<code>` returns the list of all the IRIS that match the city code as an array
`/api/city/search/<query>` uses the same function as `/search` uses to get a city, then get all the IRIS in the matched city and returns the list of IRIS in this city as well as the matched city's code and name, making it easier to detect unwanted results.